### PR TITLE
Add support notes for Maya 2019 and 2020

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The UI creation simply be skipped in that case.
 
 Supported Platforms: **Windows** (Linux and OSX probably as well, but untested)
 
-Supported Maya Versions: **2016, 2017, 2018**
+Supported Maya Versions: **2016, 2017, 2018, 2019, 2020**
 
 Author: **Fabian Geisler**
 


### PR DESCRIPTION
I've tested with Maya **2020.4** only for now, but I assume it will work with **2019** as well.

